### PR TITLE
Added X URLs to manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,7 +18,11 @@
         "https://*.twitter.com/*",
         "http://*.twitter.com/*",
         "https://twitter.com/*",
-        "http://twitter.com/*"
+        "http://twitter.com/*",
+        "https://*.x.com/*",
+        "http://*.x.com/*",
+        "https://x.com/*",
+        "http://x.com/*"
       ]
     }
   ],


### PR DESCRIPTION
Fixed extension not working for Twitter's rebrand to https://x.com by adding x.com URLs to the manifest.json file.